### PR TITLE
fix: swapped concentration/direction in term table

### DIFF
--- a/src/components/termTable.tsx
+++ b/src/components/termTable.tsx
@@ -99,10 +99,10 @@ export default function TermTable({ terms }: { terms: { __typename?: "GeneSet" |
                     {timepoint}
                   </td>
                   <td>
-                    {direction}
+                    {concentration}
                   </td>
                   <td>
-                    {concentration}
+                    {direction}
                   </td>
 
                   <td className='w-3/12'>


### PR DESCRIPTION
Fixed incorrect column mapping where concentration and direction were swapped in the term table

going to add photos